### PR TITLE
Forward from Nginx request details

### DIFF
--- a/templates/default/load_balancer.conf.erb
+++ b/templates/default/load_balancer.conf.erb
@@ -18,6 +18,10 @@ server {
   }
   <% end %>
   location / {
-    proxy_pass http://<%= @resource.application.name %>;
+    proxy_pass         http://<%= @resource.application.name %>;
+    proxy_redirect     off;
+    proxy_set_header   Host             $host;
+    proxy_set_header   X-Real-IP        $remote_addr;
+    proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
   }
 }


### PR DESCRIPTION
For now, this kind of proxy_pass does not pass request host and request ip, that can break application logic totally.

For example, in rails application methods like `root_url` just don't work - they have nginx upstream name as a host.
