### PR TITLE
[COOK-2402] Cast symbol to string in load_balancer template resource

### DIFF
--- a/providers/nginx_load_balancer.rb
+++ b/providers/nginx_load_balancer.rb
@@ -38,7 +38,7 @@ action :before_deploy do
 
   template "#{node['nginx']['dir']}/sites-available/#{new_resource.application.name}.conf" do
     source new_resource.template ? new_resource.template : "load_balancer.conf.erb"
-    cookbook new_resource.template ? new_resource.cookbook_name : "application_nginx"
+    cookbook new_resource.template ? new_resource.cookbook_name.to_s : "application_nginx"
     owner "root"
     group "root"
     mode "644"


### PR DESCRIPTION
Convert the cookbook name from a symbol to a string, so that the template
resource being created works when a custom template is used.
