### PR TITLE
[COOK-2579]: Support one or more unix sockets in nginx upstream

### DIFF
--- a/providers/nginx_load_balancer.rb
+++ b/providers/nginx_load_balancer.rb
@@ -42,7 +42,10 @@ action :before_deploy do
     owner "root"
     group "root"
     mode "644"
-    variables :resource => new_resource, :hosts => new_resource.find_matching_role(new_resource.application_server_role, false)
+    variables(:resource => new_resource,
+              :hosts => new_resource.find_matching_role(new_resource.application_server_role, false),
+              :application_socket => Array(new_resource.application_socket)
+             )
     notifies :reload, resources(:service => 'nginx')
   end
 

--- a/resources/nginx_load_balancer.rb
+++ b/resources/nginx_load_balancer.rb
@@ -25,6 +25,7 @@ attribute :template, :kind_of => [String, NilClass], :default => nil
 attribute :server_name, :kind_of => [String, Array], :default => node['fqdn']
 attribute :port, :kind_of => Integer, :default => 80
 attribute :application_port, :kind_of => Integer, :default => 8000
+attribute :application_socket, :kind_of => [Array, String, NilClass], :default => nil
 attribute :static_files, :kind_of => Hash, :default => {}
 attribute :ssl, :kind_of => [ TrueClass, FalseClass ], :default => false
 attribute :ssl_certificate, :kind_of => String, :default => "#{node['fqdn']}.crt"

--- a/templates/default/load_balancer.conf.erb
+++ b/templates/default/load_balancer.conf.erb
@@ -1,4 +1,9 @@
 upstream <%= @resource.application.name %> {
+  <% unless @application_socket.empty? -%>
+    <% @application_socket.each do |socket_name| -%>
+  server unix:<%= socket_name %>;
+    <% end -%>
+  <% end -%>
   <% @hosts.each do |node| %>
   server <%= node.attribute?('cloud') ? node['cloud']['local_ipv4'] : node['ipaddress'] %>:<%= @resource.application_port %>;
   <% end %>


### PR DESCRIPTION
New (better) version of https://github.com/opscode-cookbooks/application_nginx/pull/5

The file `resources/nginx_load_balancer.rb` restricts `application_port` to be an Integer, this change adds `application_socket` and `application_sockets` to define a socket or multiple sockets.
