### PR TITLE
[COOK-2579] Allow a string unix socket for application_port

### DIFF
--- a/resources/nginx_load_balancer.rb
+++ b/resources/nginx_load_balancer.rb
@@ -24,7 +24,7 @@ attribute :application_server_role, :kind_of => [String, Symbol, NilClass], :def
 attribute :template, :kind_of => [String, NilClass], :default => nil
 attribute :server_name, :kind_of => [String, Array], :default => node['fqdn']
 attribute :port, :kind_of => Integer, :default => 80
-attribute :application_port, :kind_of => Integer, :default => 8000
+attribute :application_port, :kind_of => [String, Integer], :default => 8000
 attribute :static_files, :kind_of => Hash, :default => {}
 attribute :ssl, :kind_of => [ TrueClass, FalseClass ], :default => false
 attribute :ssl_certificate, :kind_of => String, :default => "#{node['fqdn']}.crt"

--- a/templates/default/load_balancer.conf.erb
+++ b/templates/default/load_balancer.conf.erb
@@ -2,9 +2,9 @@ upstream <%= @resource.application.name %> {
   <% if @resource.application_port.is_a?(String) && @resource.application_port.to_i == 0 %>
   server unix:<%= @resource.application_port %>;
   <% else %>
-  <% @hosts.each do |node| %>
+    <% @hosts.each do |node| %>
   server <%= node.attribute?('cloud') ? node['cloud']['local_ipv4'] : node['ipaddress'] %>:<%= @resource.application_port %>;
-  <% end %>
+    <% end %>
   <% end %>
 }
 

--- a/templates/default/load_balancer.conf.erb
+++ b/templates/default/load_balancer.conf.erb
@@ -1,6 +1,10 @@
 upstream <%= @resource.application.name %> {
+  <% if @resource.application_port.is_a?(String) && @resource.application_port.to_i == 0 %>
+  server unix:<%= @resource.application_port %>;
+  <% else %>
   <% @hosts.each do |node| %>
   server <%= node.attribute?('cloud') ? node['cloud']['local_ipv4'] : node['ipaddress'] %>:<%= @resource.application_port %>;
+  <% end %>
   <% end %>
 }
 


### PR DESCRIPTION
Adds functionality to application_port while remaining completely backwards-compatible.

Also allows application_nginx to be used with chef-solo.
