### PR TITLE
[COOK-3432] fix to WARN: Chef::Mixin::LanguageIncludeRecipe is deprecated, use Chef::DSL::Recipe

### DIFF
--- a/providers/nginx_load_balancer.rb
+++ b/providers/nginx_load_balancer.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-include Chef::Mixin::LanguageIncludeRecipe
+include Chef::DSL::Recipe
 
 action :before_compile do
 


### PR DESCRIPTION
same ticket as [COOK-3432] in opscode-cookbooks/application_python@f7b63bf
just a warning fix, move along, nothing else to see here 
