### PR TITLE
Set nginx dependency to ~> 2.4.4

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,4 +7,4 @@ long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "2.0.3"
 
 depends "application", "~> 4.0"
-depends "nginx"
+depends "nginx", "~> 2.4.4"


### PR DESCRIPTION
Nginx cookbook 2.5.0 has changed the way this cookbook's nginx_load_balancer is expecting to generate templates using nginx_site.  Commit: https://github.com/opscode-cookbooks/nginx/commit/094685b2c649d80fb7c58b0cf0805820dcbe174c

The proper fix is probably to adjust nginx_load_balancer, but this quick dependency changes solves the problem for me and may be useful to others until a full patch is made.
