### PR TITLE
Fixed undefined method error process_hosts for Chef 12 compatibility

### DIFF
--- a/providers/nginx_load_balancer.rb
+++ b/providers/nginx_load_balancer.rb
@@ -69,9 +69,6 @@ end
 action :after_restart do
 end
 
-
-protected
-
 def process_hosts(nodes)
   nodes.map do |n|
     if n.is_a?(String)


### PR DESCRIPTION
Protected methods are no longer visible to Chef 12 templates which breaks this cookbook.  See more as described in https://github.com/poise/application_nginx/issues/20